### PR TITLE
Add v2 version of ingress schema

### DIFF
--- a/ingress.yaml
+++ b/ingress.yaml
@@ -1,3 +1,22 @@
+v2:
+  requires:
+    type: object
+    properties:
+      service:
+        type: string
+      port:
+        type: integer
+      namespace:
+        type: string
+      prefix:
+        type: string
+      rewrite:
+        type: string
+    required:
+      - service
+      - port
+      - namespace
+      - prefix
 v1:
   requires:
     type: object


### PR DESCRIPTION
The current one makes it impossible to handle cross-model relations. Making namespace field required vs just optional since it's easy to just pass in `self.model.name`.

Will help fix CI for https://github.com/canonical/istio-operators/pull/31